### PR TITLE
fix(theme): Make `ColorHelper.parseColor` return given value if it was not found in the palette or miscellaneous

### DIFF
--- a/packages/theme/src/roots/palette/entity/color-helper.ts
+++ b/packages/theme/src/roots/palette/entity/color-helper.ts
@@ -1,15 +1,19 @@
-import { darken, getLuminance, hsla, parseToHsl } from 'polished';
+import { darken, getLuminance, parseToHsl } from 'polished';
 
 import { Color } from '@brix-ui/types/palette';
-import type { Theme } from '@brix-ui/theme';
+
+import type { Theme } from '../../../entity';
+import type { MiscellaneousProps } from '../../miscellaneous';
 
 export class ColorHelper {
-  public constructor(private readonly palette: Theme['palette']) {}
+  public constructor(private readonly palette: Theme['palette'], private readonly miscellaneous: MiscellaneousProps) {}
 
-  public parseColor(color: string): string {
-    // `color` can be missing from palette
-    // @ts-expect-error
-    return hsla({ alpha: 1, ...parseToHsl(this.palette[color] || color) });
+  public parseColor(color = ''): string {
+    const fromTheme =
+      // @ts-expect-error
+      this.palette[color] || this.miscellaneous[color.replace(/-([a-z])/g, ([, match]) => match.toUpperCase())];
+
+    return fromTheme || color;
   }
 
   public getContrastingColor(color: string): string {

--- a/packages/theme/src/theme-provider/theme-provider.context.tsx
+++ b/packages/theme/src/theme-provider/theme-provider.context.tsx
@@ -34,7 +34,18 @@ const ThemeProvider: FC<ThemeProviderProps> = ({ children, theme = {} }) => {
         ...paletteOverride[themeMode],
       };
 
-      const colorHelper = new ColorHelper(palette);
+      const miscellaneous = {
+        ...merge(
+          {
+            ...defaultTheme.miscellaneous,
+          },
+          {
+            ...miscelaneousOverride,
+          }
+        ),
+      };
+
+      const colorHelper = new ColorHelper(palette, miscellaneous);
 
       return {
         palette,
@@ -42,16 +53,7 @@ const ThemeProvider: FC<ThemeProviderProps> = ({ children, theme = {} }) => {
           ...defaultTheme.breakpoints,
           ...breakpointsOverride,
         },
-        miscellaneous: {
-          ...merge(
-            {
-              ...defaultTheme.miscellaneous,
-            },
-            {
-              ...miscelaneousOverride,
-            }
-          ),
-        },
+        miscellaneous,
         typography: {
           ...defaultTheme.typography,
           ...typographyOverride,


### PR DESCRIPTION
Fixes #260