### PR TITLE
Blocks

### DIFF
--- a/packages/core/src/block/block.props.d.ts
+++ b/packages/core/src/block/block.props.d.ts
@@ -1,16 +1,15 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 
-import { Axis, Indent, IntrinsicComponent, StylableComponent, Taggable } from '@brix-ui/types/component';
+import type { Gapable, Indent, IntrinsicComponent, StylableComponent, Taggable } from '@brix-ui/types/component';
 import type { HtmlTag, TextTag } from '@brix-ui/types/html';
-import type { Values } from '@brix-ui/utils/types';
 
 export interface BlockProps
   extends PropsWithChildren<IntrinsicComponent<HTMLAttributes<HTMLElement>>>,
     StylableComponent,
+    Gapable,
     Taggable<Exclude<HtmlTag, TextTag>> {
   isInline?: boolean;
 
   margin?: Indent;
   padding?: Indent;
-  gap?: Partial<Record<Values<typeof Axis>, string>> | string;
 }

--- a/packages/core/src/block/block.styles.ts
+++ b/packages/core/src/block/block.styles.ts
@@ -1,12 +1,25 @@
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
+import type { Gapable } from '@brix-ui/types/component';
 import { applyDisplayNames, parseIndent } from '@brix-ui/utils/functions';
 
 import type { BlockProps } from './block.props';
 
-const parseGap = (gap: BlockProps['gap']): FlattenSimpleInterpolation | undefined => {
-  if (!gap) {
-    return;
+const parseGap = ({
+  gap,
+  verticalGap,
+  horizontalGap,
+}: Pick<BlockProps, keyof Gapable>): FlattenSimpleInterpolation | undefined => {
+  /**
+   * @deprecated
+   */
+  if (typeof gap === 'object') {
+    return css`
+      & > *:not(:last-child) {
+        margin-right: ${gap.horizontal};
+        margin-bottom: ${gap.vertical};
+      }
+    `;
   }
 
   if (typeof gap === 'string') {
@@ -20,8 +33,8 @@ const parseGap = (gap: BlockProps['gap']): FlattenSimpleInterpolation | undefine
 
   return css`
     & > *:not(:last-child) {
-      margin-right: ${gap.horizontal};
-      margin-bottom: ${gap.vertical};
+      margin-right: ${horizontalGap};
+      margin-bottom: ${verticalGap};
     }
   `;
 };
@@ -33,13 +46,13 @@ const Block = styled.div<
     $gap?: BlockProps['gap'];
   }
 >(
-  ({ $margin: margin, $padding: padding, $gap: gap }) => css`
+  ({ $margin: margin, $padding: padding, $gap: gap, horizontalGap, verticalGap }) => css`
     display: block;
 
     margin: ${parseIndent(margin)};
     padding: ${parseIndent(padding)};
 
-    ${parseGap(gap)};
+    ${parseGap({ gap, horizontalGap, verticalGap })};
 
     &[data-inline] {
       display: inline-block;

--- a/packages/core/src/flex/flex.component.tsx
+++ b/packages/core/src/flex/flex.component.tsx
@@ -3,8 +3,8 @@ import PT from 'prop-types';
 
 import { classNames, intrinsicComponent, objectValues, orUndefined } from '@brix-ui/utils/functions';
 import type { FlexElement } from '@brix-ui/types/html';
-import { Direction as DirectionType, FlexContainer } from '@brix-ui/types/css';
-import { alignable, stylableComponent, taggable } from '@brix-ui/prop-types/common';
+import { Direction as DirectionType } from '@brix-ui/types/css';
+import { alignable, stylableComponent } from '@brix-ui/prop-types/common';
 import { extract } from '@brix-ui/prop-types/utils';
 import Direction from '@brix-ui/contexts/direction';
 
@@ -14,11 +14,11 @@ import type { FlexProps } from './flex.props';
 import Styled from './flex.styles';
 
 const Flex = intrinsicComponent<FlexProps, FlexElement>(function Flex(
-  { children, className, as, direction = DirectionType.Row, align, hasWrap, isInline, ...props },
+  { children, className, as, direction, align, hasWrap, isInline, ...props },
   ref
 ) {
   return (
-    <Direction value={direction}>
+    <Direction value={direction || DirectionType.Row}>
       <Styled.Flex
         ref={ref}
         forwardedAs={as}
@@ -37,14 +37,12 @@ const Flex = intrinsicComponent<FlexProps, FlexElement>(function Flex(
 
 Flex.propTypes = {
   ...extract([Block]),
-  ...taggable(objectValues(FlexContainer)),
 
   direction: PT.oneOf(objectValues(DirectionType)),
 
   isReversed: PT.bool,
   hasWrap: PT.bool,
 
-  ...taggable(objectValues(FlexContainer)),
   ...alignable(),
   ...stylableComponent(),
 } as WeakValidationMap<FlexProps>;

--- a/packages/core/src/flex/flex.props.d.ts
+++ b/packages/core/src/flex/flex.props.d.ts
@@ -1,7 +1,7 @@
 import type { HTMLAttributes, PropsWithChildren } from 'react';
 
-import type { Alignable, IntrinsicComponent, StylableComponent, Taggable } from '@brix-ui/types/component';
-import { Direction, FlexContainer } from '@brix-ui/types/css';
+import type { Alignable, IntrinsicComponent, StylableComponent } from '@brix-ui/types/component';
+import { Direction } from '@brix-ui/types/css';
 import type { FlexElement } from '@brix-ui/types/html';
 
 import type { Values } from '@brix-ui/utils/types';
@@ -11,7 +11,6 @@ export interface FlexProps
   extends PropsWithChildren<IntrinsicComponent<HTMLAttributes<FlexElement>>>,
     StylableComponent,
     Alignable,
-    Taggable<Values<typeof FlexContainer>>,
     BlockProps {
   direction?: Values<typeof Direction>;
 

--- a/packages/core/src/flex/flex.styles.ts
+++ b/packages/core/src/flex/flex.styles.ts
@@ -40,17 +40,23 @@ const setAlignment = ({
   `;
 };
 
+const getDirection = (direction: FlexProps['direction'], isReversed: FlexProps['isReversed']): string | undefined => {
+  if (isReversed !== undefined) {
+    return `${direction || Direction.Row}${safeFallback(isReversed, '-reverse')}`;
+  }
+
+  return direction;
+};
+
 const Flex = styled(Block)<
   Omit<FlexProps, 'direction' | 'align'> & {
     $direction: FlexProps['direction'];
     $align: FlexProps['align'];
   }
->(({ $direction: direction = Direction.Row, isReversed, $align: align, horizontalAlign, verticalAlign }) => {
-  const flexDirection = safeFallback(direction || isReversed, `${direction}${safeFallback(isReversed, '-reverse')}`);
-
+>(({ $direction: direction, isReversed, $align: align, horizontalAlign, verticalAlign }) => {
   return css`
     display: flex;
-    flex-direction: ${flexDirection};
+    flex-direction: ${getDirection(direction, isReversed)};
 
     ${setAlignment({ direction, align, horizontalAlign, verticalAlign })};
 

--- a/packages/core/stories/dialog.story.tsx
+++ b/packages/core/stories/dialog.story.tsx
@@ -49,7 +49,7 @@ export const Basic: Story<DialogProps> = ({ title, titleAlign, ...args }) => {
   return (
     <Modal {...args} unmountOnExit>
       <Dialog {...dialogProps}>
-        <Flex direction="column" gap={{ vertical: '0.75rem' }}>
+        <Flex direction="column" verticalGap="0.75rem">
           <Text as="label" htmlFor="confirm_password">
             Are you sure you want to <Styled.Strong>reset your password?</Styled.Strong>
           </Text>
@@ -57,7 +57,7 @@ export const Basic: Story<DialogProps> = ({ title, titleAlign, ...args }) => {
           <Styled.Input id="confirm_password" type="password" isReadonly placeholder="Confirm password" />
         </Flex>
 
-        <Flex as="footer" margin={{ top: '1.5rem' }} gap={{ horizontal: '1rem' }} horizontalAlign="end">
+        <Flex as="footer" margin={{ top: '1.5rem' }} horizontalGap="1rem" horizontalAlign="end">
           <Button type="reset" appearance="faint">
             Cancel
           </Button>

--- a/packages/core/stories/radio-group.story.tsx
+++ b/packages/core/stories/radio-group.story.tsx
@@ -57,12 +57,7 @@ export const Basic: Story<RadioGroupProps> = ({ isInvalid: _isInvalid, ...args }
     <RadioGroup isInvalid={validity()} {...args} name="radio-group">
       {({ isDisabled, isInvalid }) => {
         return (
-          <Flex
-            direction="column"
-            gap={{
-              vertical: '16px',
-            }}
-          >
+          <Flex direction="column" verticalGap="16px">
             {['One', 'Two', 'Three'].map((option) => {
               return (
                 <Label aria-hidden aria-disabled={orUndefined(isDisabled)} aria-invalid={isInvalid} key={option}>

--- a/packages/core/stories/skeleton.story.tsx
+++ b/packages/core/stories/skeleton.story.tsx
@@ -41,7 +41,7 @@ const Author = styled(Flex).attrs(() => ({
 
 export const Layout: Story<SkeletonProps> = ({ isStatic }) => {
   return (
-    <Flex as="section" direction="column" gap={{ vertical: '1rem' }}>
+    <Flex as="section" direction="column" verticalGap="1rem">
       {[...new Array(3).keys()].map((key) => {
         return (
           <Card forwardedAs="article" key={key}>

--- a/packages/core/stories/tag.story.tsx
+++ b/packages/core/stories/tag.story.tsx
@@ -16,7 +16,7 @@ export const Basic: Story<TagProps> = ({ onClose, ...props }) => {
   const handleClose = () => console.log('Handle close');
 
   return (
-    <Block gap={{ horizontal: '0.5rem' }}>
+    <Block horizontalGap="0.5rem">
       <Tag>Default tag</Tag>
 
       <Tag onClose={handleClose}>Closable tag</Tag>

--- a/packages/core/tests/block.spec.tsx
+++ b/packages/core/tests/block.spec.tsx
@@ -213,9 +213,17 @@ describe('<Block />', () => {
       ` as unknown) as string,
     };
 
-    const renderWithGap = (gap: BlockProps['gap']) => {
+    const renderWithGap = ({
+      gap,
+      vertical,
+      horizontal,
+    }: {
+      gap?: BlockProps['gap'];
+      horizontal?: BlockProps['horizontalGap'];
+      vertical?: BlockProps['verticalGap'];
+    }) => {
       return render(
-        <Block data-testid={blockId} gap={gap}>
+        <Block data-testid={blockId} gap={gap} verticalGap={vertical} horizontalGap={horizontal}>
           <div />
 
           <div data-testid={lastChildId} />
@@ -225,7 +233,9 @@ describe('<Block />', () => {
 
     describe('empty value', () => {
       it('should not apply margin to children', () => {
-        const { getByTestId } = renderWithGap('');
+        const { getByTestId } = renderWithGap({
+          gap: '',
+        });
 
         ['margin-right', 'margin-bottom'].forEach((property) => {
           expect(getByTestId(blockId)).not.toHaveStyleRule(property, undefined, firstChildOptions);
@@ -235,7 +245,7 @@ describe('<Block />', () => {
 
     describe('as string', () => {
       it('should apply both right and bottom margin to all children except the last', () => {
-        const { getByTestId } = renderWithGap('1rem');
+        const { getByTestId } = renderWithGap({ gap: '1rem' });
 
         ['margin-right', 'margin-bottom'].forEach((property) => {
           expect(getByTestId(blockId)).toHaveStyleRule(property, '1rem', firstChildOptions);

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -16,6 +16,7 @@
     "@brix-ui/theme": "^2.0.0",
     "@brix-ui/types": "^2.0.0",
     "@brix-ui/utils": "^2.0.0",
+    "@brix-ui/core": "^2.0.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/grid/src/area-builder/entity/cell.d.ts
+++ b/packages/grid/src/area-builder/entity/cell.d.ts
@@ -1,6 +1,7 @@
 import type { CellProps } from '../../cell';
 
-export interface Cell extends Pick<CellProps, 'offset'> {
+export interface Cell {
   id: string;
   size?: number;
+  offset?: Exclude<CellProps['offset'], number>;
 }

--- a/packages/grid/src/cell/cell.component.tsx
+++ b/packages/grid/src/cell/cell.component.tsx
@@ -6,7 +6,8 @@ import { classNames, intrinsicComponent } from '@brix-ui/utils/functions';
 import { breakpointProps, stylableComponent } from '@brix-ui/prop-types/common';
 import useBreakpointProps from '@brix-ui/hooks/use-breakpoint-props';
 import { useTheme } from '@brix-ui/theme/hooks';
-
+import Flex from '@brix-ui/core/flex';
+import { extract } from '@brix-ui/prop-types/utils';
 import { useAreaBuilderContext } from '../area-builder';
 
 import type { CellBreakpointProps, CellProps } from './cell.props';
@@ -39,7 +40,9 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
     dispatcher.mountCell({
       id,
       size: currentBreakpointProps.size,
-      offset: currentBreakpointProps.offset,
+      offset: Array.isArray(currentBreakpointProps.offset)
+        ? currentBreakpointProps.offset
+        : [currentBreakpointProps.offset, currentBreakpointProps.offset],
     });
   }, [id]);
 
@@ -51,8 +54,8 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
       className={classNames('cell', className)}
       areas={areas}
       area={id}
+      direction={direction}
       $size={size}
-      $direction={direction}
       {...props}
     >
       {children}
@@ -67,6 +70,7 @@ const cellBreakpointData: WeakValidationMap<CellBreakpointProps> = {
 
 Cell.propTypes = {
   area: PT.string,
+  ...extract([Flex]),
   ...breakpointProps(cellBreakpointData),
 
   ...stylableComponent(),

--- a/packages/grid/src/cell/cell.props.d.ts
+++ b/packages/grid/src/cell/cell.props.d.ts
@@ -1,15 +1,11 @@
-import type { HTMLAttributes, PropsWithChildren } from 'react';
-
-import type { IntrinsicComponent, StylableComponent, BreakpointsProps } from '@brix-ui/types/component';
+import type { FlexProps } from '@brix-ui/core/flex';
+import type { BreakpointsProps } from '@brix-ui/types/component';
 
 export interface CellBreakpointProps {
   size?: number;
-  offset?: [number?, number?];
+  offset?: [number?, number?] | number;
 }
 
-export interface CellProps
-  extends BreakpointsProps<CellBreakpointProps>,
-    PropsWithChildren<IntrinsicComponent<HTMLAttributes<HTMLDivElement>>>,
-    StylableComponent {
+export interface CellProps extends BreakpointsProps<CellBreakpointProps>, FlexProps {
   area?: string;
 }

--- a/packages/grid/src/cell/cell.styles.ts
+++ b/packages/grid/src/cell/cell.styles.ts
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 
 import { applyDisplayNames } from '@brix-ui/utils/functions';
 import { Direction } from '@brix-ui/types/css';
-import { Values } from '@brix-ui/utils/types';
 
 import type { AreaBuilderState } from '../area-builder/reducer';
 
@@ -11,9 +10,9 @@ import type { CellProps } from './cell.props';
 const Cell = styled.div<{
   area: CellProps['area'];
   areas: AreaBuilderState['areas'];
+  direction?: CellProps['direction'];
   $size: CellProps['size'];
-  $direction?: Values<typeof Direction>;
-}>(({ area, areas, $size: size, $direction: direction }) => {
+}>(({ area, areas, $size: size, direction }) => {
   if (!size || size === 1) {
     return css`
       grid-area: ${area};

--- a/packages/grid/src/grid/grid.component.tsx
+++ b/packages/grid/src/grid/grid.component.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo, WeakValidationMap } from 'react';
-import PT from 'prop-types';
 
-import { applyPolymorphicFunctionProp, classNames, intrinsicComponent, objectValues } from '@brix-ui/utils/functions';
+import { applyPolymorphicFunctionProp, classNames, intrinsicComponent, orUndefined } from '@brix-ui/utils/functions';
 import type { With } from '@brix-ui/utils/types';
 import { extract } from '@brix-ui/prop-types/utils';
-import { breakpointProps, stylableComponent, polymorphicBreakpointProp } from '@brix-ui/prop-types/common';
-import Direction from '@brix-ui/contexts/direction';
-import { Direction as DirectionType } from '@brix-ui/types/css';
-import Block from '@brix-ui/core/block';
+import { breakpointProps, stylableComponent, polymorphicBreakpointProp, gapable } from '@brix-ui/prop-types/common';
+import Flex from '@brix-ui/core/flex';
 import useBreakpointProps from '@brix-ui/hooks/use-breakpoint-props';
 import { useTheme } from '@brix-ui/theme/hooks';
+import { Direction } from '@brix-ui/types/css';
 
 import { useAreaBuilder, AreaBuilder } from '../area-builder';
 
@@ -17,13 +15,13 @@ import type { GridBreakpointProps, GridProps } from './grid.props';
 import Styled from './grid.styles';
 
 const Grid = intrinsicComponent<GridProps>(function Grid(
-  { children, className, as, direction, gap, template, maxWidth, sm, md, lg, xl, ...props },
+  { children, className, as, direction, isInline, gap, template, maxWidth, sm, md, lg, xl, ...props },
   ref
 ) {
   const [grid, dispatcher] = useAreaBuilder();
 
   const areas = useMemo(() => {
-    if (direction === DirectionType.Column) {
+    if (direction === Direction.Column) {
       return grid.areas.map((area) => `'${area}'`).join(' ');
     }
 
@@ -47,39 +45,37 @@ const Grid = intrinsicComponent<GridProps>(function Grid(
   ) as With<GridBreakpointProps, { currentBreakpoint: number }>;
 
   return (
-    <Direction value={direction}>
-      <AreaBuilder areas={grid.areas} dispatcher={dispatcher}>
-        <Styled.Grid
-          ref={ref}
-          forwardedAs={as}
-          className={classNames('grid', className)}
-          $direction={currentBreakpointProps.direction}
-          $gap={currentBreakpointProps.gap}
-          $maxWidth={applyPolymorphicFunctionProp(currentBreakpointProps.maxWidth, currentBreakpoint)}
-          template={applyPolymorphicFunctionProp(currentBreakpointProps.template, grid.fractionsCount)}
-          areas={areas}
-          fractionsCount={grid.fractionsCount}
-          {...props}
-        >
-          {children}
-        </Styled.Grid>
-      </AreaBuilder>
-    </Direction>
+    <AreaBuilder areas={grid.areas} dispatcher={dispatcher}>
+      <Styled.Grid
+        ref={ref}
+        forwardedAs={as}
+        className={classNames('grid', className)}
+        direction={currentBreakpointProps.direction}
+        $gap={currentBreakpointProps.gap}
+        $maxWidth={applyPolymorphicFunctionProp(currentBreakpointProps.maxWidth, currentBreakpoint)}
+        template={applyPolymorphicFunctionProp(currentBreakpointProps.template, grid.fractionsCount)}
+        areas={areas}
+        fractionsCount={grid.fractionsCount}
+        data-inline={orUndefined(isInline)}
+        {...props}
+      >
+        {children}
+      </Styled.Grid>
+    </AreaBuilder>
   );
 });
 
-const { gap, isInline: _, ...blockPropTypes } = extract([Block]);
+const { isReversed: _r, hasWrap: _w, ...flexPropTypes } = extract([Flex]);
 
-const gridBreakpointData = {
-  gap,
-  direction: PT.oneOf(objectValues(DirectionType)),
+const gridBreakpointData: WeakValidationMap<GridBreakpointProps> = {
+  ...gapable,
   template: polymorphicBreakpointProp(),
   maxWidth: polymorphicBreakpointProp(),
 };
 
 Grid.propTypes = {
   ...breakpointProps(gridBreakpointData),
-  ...blockPropTypes,
+  ...flexPropTypes,
 
   ...stylableComponent(),
 } as WeakValidationMap<GridProps>;

--- a/packages/grid/src/grid/grid.props.d.ts
+++ b/packages/grid/src/grid/grid.props.d.ts
@@ -1,27 +1,13 @@
-import type { HTMLAttributes, PropsWithChildren } from 'react';
+import type { FlexProps } from '@brix-ui/core/flex';
+import type { BreakpointsProps, Gapable, PolymorphicBreakpointProp } from '@brix-ui/types/component';
 
-import type { BlockProps } from '@brix-ui/core/block';
-import type {
-  IntrinsicComponent,
-  StylableComponent,
-  BreakpointsProps,
-  PolymorphicBreakpointProp,
-} from '@brix-ui/types/component';
-import type { Values } from '@brix-ui/utils/types';
-import { Direction } from '@brix-ui/types/css';
-
-export interface GridBreakpointProps extends Pick<BlockProps, 'gap'> {
-  direction?: Values<typeof Direction>;
-  /**
-   * Did not use PolymorphicBreakpointProp here
-   * as it may mislead to having a different argument available
-   */
+// Did not use PolymorphicBreakpointProp on the `template`
+// as it may mislead to having a different argument available
+export interface GridBreakpointProps extends Pick<FlexProps, 'direction' | Extract<keyof Gapable, 'gap'>> {
   template?: ((fractionsCount: number) => string) | string;
   maxWidth?: PolymorphicBreakpointProp;
 }
 
 export interface GridProps
   extends BreakpointsProps<GridBreakpointProps>,
-    PropsWithChildren<IntrinsicComponent<HTMLAttributes<HTMLDivElement>>>,
-    StylableComponent,
-    Omit<BlockProps, 'isInline' | 'gap'> {}
+    Omit<FlexProps, 'isReversed' | 'hasWrap' | Exclude<keyof Gapable, 'gap'>> {}

--- a/packages/grid/src/grid/grid.styles.ts
+++ b/packages/grid/src/grid/grid.styles.ts
@@ -1,47 +1,33 @@
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { applyDisplayNames } from '@brix-ui/utils/functions';
-import Block from '@brix-ui/core/block';
 import { Direction } from '@brix-ui/types/css';
+import Flex from '@brix-ui/core/flex';
 
 import type { GridProps } from './grid.props';
 
-const parseGap = (gap: GridProps['gap']): FlattenSimpleInterpolation | undefined => {
-  if (!gap) {
-    return;
-  }
-
-  if (typeof gap === 'string') {
-    return css`
-      grid-gap: ${gap};
-    `;
-  }
-
-  return css`
-    grid-row-gap: ${gap.vertical};
-    grid-column-gap: ${gap.horizontal};
-  `;
-};
-
-const Grid = styled(Block)<{
-  $direction: GridProps['direction'];
+const Grid = styled(Flex)<{
   $gap: GridProps['gap'];
   $maxWidth: Extract<GridProps['maxWidth'], string> | undefined;
   template: Extract<GridProps['template'], string> | undefined;
   areas: string;
   fractionsCount: number;
-}>(({ $direction: direction, $gap: gap, $maxWidth: maxWidth, areas, template, fractionsCount }) => {
+}>(({ direction, $gap: gap, $maxWidth: maxWidth, areas, template, fractionsCount }) => {
   const templateDirection = direction === Direction.Column ? Direction.Row : Direction.Column;
 
   return css`
     display: grid;
 
-    ${parseGap(gap)};
+    grid-gap: ${gap};
 
     grid-template-areas: ${areas};
     ${`grid-template-${templateDirection}s`}: ${template || `repeat(${fractionsCount}, 1fr)`};
 
     max-width: ${maxWidth};
+
+    &[data-inline] {
+      display: inline-grid;
+    }
   `;
 });
 

--- a/packages/grid/stories/grid.story.tsx
+++ b/packages/grid/stories/grid.story.tsx
@@ -38,13 +38,13 @@ const mapCells = (count: number, content?: (index: number) => ReactNode): ReactE
   });
 };
 
-export const Basic: Story = () => {
-  return <Grid>{mapCells(3)}</Grid>;
+export const Basic: Story = (args) => {
+  return <Grid {...args}>{mapCells(3)}</Grid>;
 };
 
-export const MultipleRows: Story = () => {
+export const MultipleRows: Story = (args) => {
   return (
-    <Grid direction="column" gap="1rem">
+    <Grid direction="column" gap="1rem" {...args}>
       <Cell>
         <Grid>{mapCells(2)}</Grid>
       </Cell>
@@ -56,9 +56,9 @@ export const MultipleRows: Story = () => {
   );
 };
 
-export const SettingColumnWidth: Story = () => {
+export const SettingColumnWidth: Story = (args) => {
   return (
-    <Grid>
+    <Grid {...args}>
       <Cell>
         <Box>One of three columns</Box>
       </Cell>
@@ -74,9 +74,9 @@ export const SettingColumnWidth: Story = () => {
   );
 };
 
-export const Gaps: Story = () => {
+export const Gaps: Story = (args) => {
   return (
-    <Grid direction="column" gap="1rem">
+    <Grid direction="column" gap="1rem" {...args}>
       <Cell>
         <Grid gap="2rem">{mapCells(3)}</Grid>
       </Cell>
@@ -88,9 +88,9 @@ export const Gaps: Story = () => {
   );
 };
 
-export const Offsets: Story = () => {
+export const Offsets: Story = (args) => {
   return (
-    <Grid direction="column" gap="1rem">
+    <Grid direction="column" gap="1rem" {...args}>
       <Cell>
         <Grid gap="2rem">
           <Cell>
@@ -122,16 +122,11 @@ export const Offsets: Story = () => {
   );
 };
 
-export const Nesting: Story = () => {
+export const Nesting: Story = (args) => {
   return (
-    <Grid direction="column" gap="1rem">
+    <Grid direction="column" gap="1rem" {...args}>
       <Cell>
-        <Box
-          direction="column"
-          gap={{
-            vertical: '1rem',
-          }}
-        >
+        <Box direction="column" verticalGap="1rem">
           <Text variant="h3">One of two rows</Text>
 
           <Grid>{mapCells(2)}</Grid>
@@ -139,12 +134,7 @@ export const Nesting: Story = () => {
       </Cell>
 
       <Cell>
-        <Box
-          direction="column"
-          gap={{
-            vertical: '1rem',
-          }}
-        >
+        <Box direction="column" verticalGap="1rem">
           <Text variant="h3">One of two rows</Text>
 
           <Grid>{mapCells(2)}</Grid>

--- a/packages/grid/tests/grid.spec.tsx
+++ b/packages/grid/tests/grid.spec.tsx
@@ -38,40 +38,12 @@ describe('<Grid />', () => {
     });
 
     describe('as string', () => {
-      it('should apply single grid-gap', () => {
+      it('should apply single `grid-gap`', () => {
         const { getByTestId } = renderWithProps({
           gap: '1px',
         });
 
         expect(getByTestId(gridId)).toHaveStyleRule('grid-gap', '1px');
-      });
-    });
-
-    describe('as axes object', () => {
-      describe('when one axis is not set', () => {
-        it('should apply only the defined one', () => {
-          const { getByTestId } = renderWithProps({
-            gap: {
-              vertical: '1px',
-            },
-          });
-
-          expect(getByTestId(gridId)).toHaveStyleRule('grid-row-gap', '1px');
-        });
-      });
-
-      describe('when both axes are set', () => {
-        it('should apply gap in both directions', () => {
-          const { getByTestId } = renderWithProps({
-            gap: {
-              vertical: '1px',
-              horizontal: '2px',
-            },
-          });
-
-          expect(getByTestId(gridId)).toHaveStyleRule('grid-row-gap', '1px');
-          expect(getByTestId(gridId)).toHaveStyleRule('grid-column-gap', '2px');
-        });
       });
     });
   });

--- a/packages/prop-types/src/common/gapable.ts
+++ b/packages/prop-types/src/common/gapable.ts
@@ -1,0 +1,8 @@
+import type { WeakValidationMap } from 'react';
+import PT from 'prop-types';
+
+import type { Gapable } from '@brix-ui/types/component';
+
+import { record } from '../utils';
+
+export const gapable: WeakValidationMap<Gapable> = record(['gap', 'horizontalGap', 'verticalGap'], PT.string);

--- a/packages/prop-types/src/common/index.ts
+++ b/packages/prop-types/src/common/index.ts
@@ -1,4 +1,5 @@
 export * from './indent';
+export * from './gapable';
 export * from './ref-prop';
 export * from './taggable';
 export * from './affixable';

--- a/packages/theme/stories/palette.story.tsx
+++ b/packages/theme/stories/palette.story.tsx
@@ -117,39 +117,16 @@ const Family: FC<{
   colors: PaletteProps;
 }> = ({ name, colors }) => {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      gap={{
-        vertical: '16px',
-      }}
-    >
+    <Flex direction="column" align="center" verticalGap="16px">
       <Text variant="h2">{capitalize(name)}</Text>
 
-      <Flex
-        gap={{
-          horizontal: '24px',
-        }}
-      >
+      <Flex horizontalGap="24px">
         {['strong', 'weak'].map((member) => {
           return (
-            <Flex
-              key={member}
-              direction="column"
-              gap={{
-                vertical: '12px',
-              }}
-              align="center"
-            >
+            <Flex key={member} direction="column" verticalGap="12px" align="center">
               <Text variant="h4">{member}</Text>
 
-              <Flex
-                direction="column"
-                align="center"
-                gap={{
-                  vertical: '4px',
-                }}
-              >
+              <Flex direction="column" align="center" verticalGap="4px">
                 {['up', '', 'down'].map((shade) => {
                   const color = `${name}-${member}${shade ? `-${shade}` : ''}`;
 
@@ -172,12 +149,7 @@ const Family: FC<{
 
 export const Colors: Story<PaletteProps> = (args) => {
   return (
-    <Flex
-      align="center"
-      gap={{
-        horizontal: '64px',
-      }}
-    >
+    <Flex align="center" horizontalGap="64px">
       {['base', 'faint', 'accent', 'critical', 'success'].map((family) => (
         <Family key={family} name={family} colors={args} />
       ))}

--- a/packages/types/src/component/gapable.d.ts
+++ b/packages/types/src/component/gapable.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @deprecated
+ */
+interface Gapable extends Partial<Record<'verticalGap' | 'horizontalGap', string>> {
+  gap?:
+    | string
+    | {
+        vertical?: string;
+        horizontal?: string;
+      };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Gapable extends Partial<Record<'gap' | 'verticalGap' | 'horizontalGap', string>> {}

--- a/packages/types/src/component/index.ts
+++ b/packages/types/src/component/index.ts
@@ -1,5 +1,6 @@
 export * from './axis';
 export * from './intent';
+export type { Gapable } from './gapable';
 export type { Taggable } from './taggable';
 export type { Delayable } from './delayable';
 export type { Affixable } from './affixable';

--- a/packages/types/src/css/flex-container.ts
+++ b/packages/types/src/css/flex-container.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated
+ */
 export const FlexContainer = {
   Div: 'div',
   Ul: 'ul',

--- a/packages/utils/src/functions/parse-alignment.ts
+++ b/packages/utils/src/functions/parse-alignment.ts
@@ -2,9 +2,6 @@ import { Align } from '@brix-ui/types/css';
 
 import type { Values } from '../types';
 
-/**
- * @package
- */
 export function parseAlignment(alignment?: Values<typeof Align>): string {
   switch (alignment) {
     case 'start':


### PR DESCRIPTION
### What's new:

**Block, Flex**
Now, instead of just `gap`, we have `horizontalGap` and `verticalGap`. This practice of splitting complex props proved to be more convenient than just specifying an object.
_Old `gap` accepting an object is now deprecated._

**Grid, Cell**
Those components now extend directly from `Flex`.
Grid adds new css-grid behaviour, while `Cell` can now fully be used in conjunction with the features of its parent.

**Types**
Added new `Gapable` type.