### PR TITLE
Text updates

### DIFF
--- a/packages/core/src/text/index.ts
+++ b/packages/core/src/text/index.ts
@@ -1,6 +1,6 @@
 import { createElement, Ref } from 'react';
 
-import { TextElement } from '@brix-ui/types/html';
+import type { TextElement } from '@brix-ui/types/html';
 import { intrinsicComponent } from '@brix-ui/utils/functions';
 
 import Text from './text.component';
@@ -42,7 +42,23 @@ const Span = intrinsicComponent<TextProps, HTMLSpanElement>(function Span(props,
   return createTextElement(props, ref, 'span');
 });
 
+const Strong = intrinsicComponent<TextProps, HTMLSpanElement>(function Strong(props, ref) {
+  return createTextElement({ weight: 'bold', ...props }, ref, 'strong');
+});
+
+const Em = intrinsicComponent<TextProps, HTMLSpanElement>(function Em(props, ref) {
+  return createTextElement({ decoration: 'italic', ...props }, ref, 'em');
+});
+
+const Code = intrinsicComponent<TextProps, HTMLSpanElement>(function Em(props, ref) {
+  return createTextElement({ appearance: 'code', ...props }, ref, 'code');
+});
+
+const Pre = intrinsicComponent<TextProps, HTMLSpanElement>(function Pre(props, ref) {
+  return createTextElement({ appearance: 'code', ...props }, ref, 'pre');
+});
+
 export type { TextProps };
-export { H1, H2, H3, H4, H5, P, Span };
+export { H1, H2, H3, H4, H5, P, Span, Strong, Em, Code, Pre };
 
 export default Text;

--- a/packages/core/src/text/index.ts
+++ b/packages/core/src/text/index.ts
@@ -42,19 +42,19 @@ const Span = intrinsicComponent<TextProps, HTMLSpanElement>(function Span(props,
   return createTextElement(props, ref, 'span');
 });
 
-const Strong = intrinsicComponent<TextProps, HTMLSpanElement>(function Strong(props, ref) {
+const Strong = intrinsicComponent<TextProps, TextElement>(function Strong(props, ref) {
   return createTextElement({ weight: 'bold', ...props }, ref, 'strong');
 });
 
-const Em = intrinsicComponent<TextProps, HTMLSpanElement>(function Em(props, ref) {
+const Em = intrinsicComponent<TextProps, TextElement>(function Em(props, ref) {
   return createTextElement({ decoration: 'italic', ...props }, ref, 'em');
 });
 
-const Code = intrinsicComponent<TextProps, HTMLSpanElement>(function Code(props, ref) {
+const Code = intrinsicComponent<TextProps, TextElement>(function Code(props, ref) {
   return createTextElement({ appearance: 'code', ...props }, ref, 'code');
 });
 
-const Pre = intrinsicComponent<TextProps, HTMLSpanElement>(function Pre(props, ref) {
+const Pre = intrinsicComponent<TextProps, HTMLPreElement>(function Pre(props, ref) {
   return createTextElement({ appearance: 'code', ...props }, ref, 'pre');
 });
 

--- a/packages/core/src/text/index.ts
+++ b/packages/core/src/text/index.ts
@@ -50,7 +50,7 @@ const Em = intrinsicComponent<TextProps, HTMLSpanElement>(function Em(props, ref
   return createTextElement({ decoration: 'italic', ...props }, ref, 'em');
 });
 
-const Code = intrinsicComponent<TextProps, HTMLSpanElement>(function Em(props, ref) {
+const Code = intrinsicComponent<TextProps, HTMLSpanElement>(function Code(props, ref) {
   return createTextElement({ appearance: 'code', ...props }, ref, 'code');
 });
 

--- a/packages/core/src/text/text.component.tsx
+++ b/packages/core/src/text/text.component.tsx
@@ -4,7 +4,7 @@ import PT, { Requireable } from 'prop-types';
 import { classNames, intrinsicComponent, objectValues } from '@brix-ui/utils/functions';
 import type { TextElement } from '@brix-ui/types/html';
 import { stylableComponent } from '@brix-ui/prop-types/common';
-import { FontVariant, TextAlign, TextDecoration, TypeVariant } from '@brix-ui/types/typography';
+import { FontVariant, FontWeight, TextAlign, TextDecoration, TypeVariant } from '@brix-ui/types/typography';
 
 import Styled from './text.styles';
 import type { TextProps } from './text.props';
@@ -28,7 +28,21 @@ Text.propTypes = {
   color: PT.string,
   align: PT.oneOf(objectValues(TextAlign)),
   decoration: PT.oneOf(objectValues(TextDecoration)),
-  weight: PT.string,
+  weight: PT.oneOf([
+    ...objectValues(FontWeight),
+    'thin',
+    'extra-light',
+    'light',
+    'regular',
+    'medium',
+    'semi-bold',
+    'bold',
+    'extra-bold',
+    'black',
+    'normal',
+    'lighter',
+    'bolder',
+  ]),
 
   lineHeightCompensation: PT.oneOfType([PT.bool, PT.func]),
 

--- a/packages/core/src/text/text.props.d.ts
+++ b/packages/core/src/text/text.props.d.ts
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, LabelHTMLAttributes, PropsWithChildren } from 'react';
 
-import { FontVariant, TextAlign, TextDecoration, TypeVariant } from '@brix-ui/types/typography';
+import { FontVariant, FontWeight, TextAlign, TextDecoration, TypeVariant } from '@brix-ui/types/typography';
 import type { IntrinsicComponent, StylableComponent } from '@brix-ui/types/component';
 import type { Values } from '@brix-ui/utils/types';
 import type { TextElement, TextTag } from '@brix-ui/types/html';
@@ -15,7 +15,20 @@ export interface TextProps
   color?: string;
   align?: Values<typeof TextAlign>;
   decoration?: Values<typeof TextDecoration>;
-  weight?: string;
+  weight?:
+    | Values<typeof FontWeight>
+    | 'thin'
+    | 'extra-light'
+    | 'light'
+    | 'regular'
+    | 'medium'
+    | 'semi-bold'
+    | 'bold'
+    | 'extra-bold'
+    | 'black'
+    | 'normal'
+    | 'lighter'
+    | 'bolder';
 
   lineHeightCompensation?: boolean | ((variant: NonNullable<TextProps['variant']>) => number);
 }

--- a/packages/core/src/text/text.styles.ts
+++ b/packages/core/src/text/text.styles.ts
@@ -26,6 +26,38 @@ const parseTextDecoration = (decoration: TextProps['decoration']): FlattenSimple
   }
 };
 
+const parseWeight = (weight: TextProps['weight']): TextProps['weight'] => {
+  switch (weight) {
+    case 'thin': {
+      return 100;
+    }
+    case 'extra-light': {
+      return 200;
+    }
+    case 'light': {
+      return 300;
+    }
+    case 'regular': {
+      return 400;
+    }
+    case 'medium': {
+      return 500;
+    }
+    case 'semi-bold': {
+      return 600;
+    }
+    case 'extra-bold': {
+      return 800;
+    }
+    case 'black': {
+      return 900;
+    }
+    default: {
+      return weight;
+    }
+  }
+};
+
 const Text = styled.p<
   Omit<TextProps, 'color' | 'align'> & {
     $color?: TextProps['color'];
@@ -50,7 +82,7 @@ const Text = styled.p<
 
       color: ${theme.colorHelper.parseColor(color)};
       text-align: ${align};
-      font-weight: ${weight};
+      font-weight: ${parseWeight(weight)};
 
       ${parseTextDecoration(decoration)};
 


### PR DESCRIPTION
### What's new

- `Text`'s `weight` prop now accepts numeric `font-weight` values (100–900) as well as their human-readable proteges (thin–black).
- `Strong`, `Em`, `Code` and `Pre` components were added to the pool of predefined `Text` components.