### PR TITLE
Grid updates

### DIFF
--- a/packages/grid/src/cell/cell.component.tsx
+++ b/packages/grid/src/cell/cell.component.tsx
@@ -21,7 +21,7 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
 
   const { breakpoints } = useTheme();
 
-  const currentBreakpointProps = useBreakpointProps(
+  const { currentBreakpoint, ...currentBreakpointProps } = useBreakpointProps<CellBreakpointProps>(
     {
       sm,
       md,
@@ -31,7 +31,7 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
       offset,
     },
     breakpoints
-  ) as CellBreakpointProps;
+  );
 
   const { current: internalId } = useRef(Math.random().toString(32).slice(2).replace(/\d+/, ''));
   const id = useMemo(() => area || internalId, [area]);
@@ -44,7 +44,7 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
         ? currentBreakpointProps.offset
         : [currentBreakpointProps.offset, currentBreakpointProps.offset],
     });
-  }, [id]);
+  }, [id, currentBreakpoint]);
 
   const direction = useDirection();
 
@@ -65,7 +65,9 @@ const Cell = intrinsicComponent<CellProps, HTMLDivElement>(function Cell(
 
 const cellBreakpointData: WeakValidationMap<CellBreakpointProps> = {
   size: PT.number,
-  offset: PT.arrayOf(PT.number) as Requireable<CellBreakpointProps['offset']>,
+  offset: PT.oneOfType([PT.arrayOf(PT.number).isRequired, PT.number.isRequired]) as Requireable<
+    CellBreakpointProps['offset']
+  >,
 };
 
 Cell.propTypes = {

--- a/packages/grid/src/grid/grid.component.tsx
+++ b/packages/grid/src/grid/grid.component.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, WeakValidationMap } from 'react';
 
 import { applyPolymorphicFunctionProp, classNames, intrinsicComponent, orUndefined } from '@brix-ui/utils/functions';
-import type { With } from '@brix-ui/utils/types';
 import { extract } from '@brix-ui/prop-types/utils';
 import { breakpointProps, stylableComponent, polymorphicBreakpointProp, gapable } from '@brix-ui/prop-types/common';
 import Flex from '@brix-ui/core/flex';
@@ -30,7 +29,7 @@ const Grid = intrinsicComponent<GridProps>(function Grid(
 
   const { breakpoints } = useTheme();
 
-  const { currentBreakpoint, ...currentBreakpointProps } = useBreakpointProps(
+  const { currentBreakpoint, ...currentBreakpointProps } = useBreakpointProps<GridBreakpointProps>(
     {
       sm,
       md,
@@ -42,7 +41,7 @@ const Grid = intrinsicComponent<GridProps>(function Grid(
       maxWidth,
     },
     breakpoints
-  ) as With<GridBreakpointProps, { currentBreakpoint: number }>;
+  );
 
   return (
     <AreaBuilder areas={grid.areas} dispatcher={dispatcher}>

--- a/packages/grid/stories/grid.story.tsx
+++ b/packages/grid/stories/grid.story.tsx
@@ -143,3 +143,15 @@ export const Nesting: Story = (args) => {
     </Grid>
   );
 };
+
+export const Container: Story = (args) => {
+  return (
+    <Grid {...args}>
+      <Cell size={12} md={{ size: 10, offset: 2 }} lg={{ size: 8, offset: 2 }} xl={{ size: 6, offset: 3 }}>
+        <Box direction="column" verticalGap="1rem">
+          <Text variant="h3">Content</Text>
+        </Box>
+      </Cell>
+    </Grid>
+  );
+};

--- a/packages/hooks/src/use-breakpoint-props.ts
+++ b/packages/hooks/src/use-breakpoint-props.ts
@@ -5,16 +5,18 @@ import { spread } from '@brix-ui/utils/functions';
 
 import useMediaQuery from './use-media-query';
 
-// @TODO [Dmytro Vasylkivskyi]: fix typing
+type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type WithCurrentBreakpoint<T = {}> = With<T, { currentBreakpoint: number }>;
+
 /**
  * Merges props from all the breakpoints up to the currently matching one.
  * Expects `xs` to be the default
  */
-export default function useBreakpointProps<
-  R extends With<Record<string, unknown>, { currentBreakpoint: number }>,
-  A extends Omit<R, 'currentBreakpoint'>,
-  B extends R
->({ sm, md, lg, xl, ...xs }: A, breakpoints: Record<'xs' | 'sm' | 'md' | 'lg' | 'xl', number>): R {
+export default function useBreakpointProps<T extends object | undefined>(
+  props: T & Record<Exclude<Breakpoint, 'xs'>, T | undefined>,
+  breakpoints: Record<Breakpoint, number>
+): WithCurrentBreakpoint<T> {
+  const { sm, md, lg, xl, ...xs } = props;
   const { xs: bpXs, sm: bpSm, md: bpMd, lg: bpLg, xl: bpXl } = breakpoints;
 
   const isSm = useMediaQuery(`screen and (min-width: ${bpSm}px)`);
@@ -22,23 +24,23 @@ export default function useBreakpointProps<
   const isLg = useMediaQuery(`screen and (min-width: ${bpLg}px)`);
   const isXl = useMediaQuery(`screen and (min-width: ${bpXl}px)`);
 
-  return useMemo(() => {
+  return useMemo<WithCurrentBreakpoint<T>>(() => {
     if (isXl) {
-      return spread({ currentBreakpoint: bpXl }, xs as B, ...([sm, md, lg, xl] as B[])) as R;
+      return spread({ currentBreakpoint: bpXl }, xs as T, ...([sm, md, lg, xl] as T[]));
     }
 
     if (isLg) {
-      return spread({ currentBreakpoint: bpLg }, xs as B, ...([sm, md, lg] as B[])) as R;
+      return spread({ currentBreakpoint: bpLg }, xs as T, ...([sm, md, lg] as T[]));
     }
 
     if (isMd) {
-      return spread({ currentBreakpoint: bpMd }, xs as B, ...([sm, md] as B[])) as R;
+      return spread({ currentBreakpoint: bpMd }, xs as T, ...([sm, md] as T[]));
     }
 
     if (isSm) {
-      return spread({ currentBreakpoint: bpSm }, xs as B, sm as B) as R;
+      return spread({ currentBreakpoint: bpSm }, xs as T, sm as T);
     }
 
-    return spread({ currentBreakpoint: bpXs }, xs as B) as B;
+    return spread({ currentBreakpoint: bpXs }, xs);
   }, [xs, isSm, sm, isMd, md, isLg, lg, isXl, xl]);
 }

--- a/packages/utils/src/functions/spread.ts
+++ b/packages/utils/src/functions/spread.ts
@@ -1,14 +1,8 @@
-import type { Values } from '@brix-ui/utils/types';
-
 /**
  * Spreads multiple objects into one
  */
-export function spread<
-  _O extends Record<string, unknown> | undefined,
-  O extends Exclude<_O, undefined>,
-  R extends Record<keyof O, Values<O>>
->(...objects: _O[]): R {
-  return objects.reduce((spreadObject, object) => {
-    return Object.assign(spreadObject, object || {});
-  }, {} as R);
+export function spread<R extends object>(...objects: (object | undefined)[]): R {
+  return objects.reduce((target, object = {}) => {
+    return Object.assign(target, object);
+  }, ({} as unknown) as R) as R;
 }


### PR DESCRIPTION
- Fixed `Cell` prop-types and memoized `dispatch`;
- Updated `spread` util function and `useBreakpointProps` hook types (make them simpler);
- Update usage of `useBreakpointProps` in `grid` package components;
- Added new `Container` story for grids.